### PR TITLE
Remove v3 from abi migration as it is not supported anymore

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,9 +2,6 @@ azure:
   settings_win:
     pool:
       vmImage: windows-2019
-bot:
-  abi_migration_branches:
-  - v3
 build_platform:
   osx_arm64: osx_64
 conda_forge_output_validation: true


### PR DESCRIPTION
See https://github.com/ignition-tooling/release-tools/issues/600 and https://github.com/ignitionrobotics/docs/blob/1ebf12f8f98e41b9174f158679051fb97b10070a/tools/versions.md .